### PR TITLE
Update JwsMac.php

### DIFF
--- a/src/JWS/JwsMac.php
+++ b/src/JWS/JwsMac.php
@@ -100,7 +100,7 @@ class JwsMac extends Jws implements Symmetric {
 	 */
 	public function verify($jws) {
 		$d = $this->prepareVerify($jws);
-		return hash_equals($d["sig"], hash_hmac($this->algos[$d["alg"]], $d["h"] . "." . $d["p"], $this->secretKey, true));
+		return hash_equals(hash_hmac($this->algos[$d["alg"]], $d["h"] . "." . $d["p"], $this->secretKey, true), $d["sig"]);
 	}
 
 	/**


### PR DESCRIPTION
According to the PHP documentation for `hash_equals()`: "It is important to provide the user-supplied string as the second parameter, rather than the first."