### PR TITLE
Fixed implicitly nullable parameter types deprecated in PHP 8.4

### DIFF
--- a/src/JWS/Exception/JwsException.php
+++ b/src/JWS/Exception/JwsException.php
@@ -13,7 +13,7 @@ use Exception;
  */
 class JwsException extends Exception {
 	// Redefine the exception so message isn't optional:
-	public function __construct($message, $code = 0, Exception $previous = null) {
+	public function __construct($message, $code = 0, ?Exception $previous = null) {
 		// Some code
 
 		// Make sure everything is assigned properly:


### PR DESCRIPTION
PHP 8.4 has deprecated implicitly nullable types. This PR fixes the issue. Tested with PHP 8.4 alpha 4.

https://wiki.php.net/rfc/deprecate-implicitly-nullable-types